### PR TITLE
Atomic check or set for deduping dispatches

### DIFF
--- a/Trunk-Transcribe/app.go
+++ b/Trunk-Transcribe/app.go
@@ -369,7 +369,7 @@ func dedupeDispatch(meta Metadata) (dupe bool) {
 	dedupeKey := fmt.Sprintf("tg.%d.start.%d.srcs%s", meta.Talkgroup, meta.StartTime, srcs)
 
 	// atomically check-or-set. Return whether the key already existed.
-	exists, _ := dedupeCache.ContainsOrAdd(dedupeKey)
+	exists, _ := dedupeCache.ContainsOrAdd(dedupeKey, true)
 	
 	return exists
 }

--- a/Trunk-Transcribe/app.go
+++ b/Trunk-Transcribe/app.go
@@ -356,21 +356,22 @@ func handleTranscription(ctx context.Context, config *Config, r *http.Request) e
 	return nil
 }
 
-// dedupe dispatches
+// dedupeDispatch checks if the specified dispatch (described by its metadata) has already been seen.
+// Returns true if the dispatch is a duplicate, false otherwise.
 func dedupeDispatch(meta Metadata) (dupe bool) {
 
+	// construct a cache key consisting of all the srcs (parties in the call),
+	// the talkgroup, and the startime
 	var srcs string
 	for _, src := range meta.SrcList {
 		srcs += fmt.Sprintf(".%v", src.Src)
 	}
 	dedupeKey := fmt.Sprintf("tg.%d.start.%d.srcs%s", meta.Talkgroup, meta.StartTime, srcs)
 
-	if dedupeCache.Contains(dedupeKey) {
-		return true
-	}
-
-	dedupeCache.Add(dedupeKey, true)
-	return false
+	// atomically check-or-set. Return whether the key already existed.
+	exists, _ := dedupeCache.ContainsOrAdd(dedupeKey)
+	
+	return exists
 }
 
 // transcribeAndUpload transcribes the audio to text, posts the text to slack and persists the audio file to S3,


### PR DESCRIPTION
Atomically check the cache for a dupe or set a value if it doesn't exist. Resolves a race condition whereby two identical dispatches arrive at the same time.