### PR TITLE
Update slack client

### DIFF
--- a/Trunk-Transcribe/app.go
+++ b/Trunk-Transcribe/app.go
@@ -563,17 +563,16 @@ func postToSlack(ctx context.Context, config *Config, key string, reader io.Read
 
 	// upload audio
 	filename := filepath.Base(key)
-	file, err := config.slackClient.UploadFile(slack.FileUploadParameters{
-		Filename:       filename,
-		Filetype:       "auto",
+	summary, err := config.slackClient.UploadFileV2Context(ctx, slack.UploadFileV2Parameters{
+		Filename:       filename,		
 		Reader:         reader,
 		InitialComment: sentances,
-		Channels:       []string{string(channelID)},
+		Channel:       string(channelID),
 	})
 	if err != nil {
 		log.Println("Error uploading file to slack: ", err)
 	} else {
-		log.Printf("Uploaded file: %s of type: %s to channel: %v", file.Name, file.Filetype, channelID)
+		log.Printf("Uploaded file: %s with titel: %s to channel: %v", summary.ID, summary.Title, channelID)
 	}
 
 	return err

--- a/Trunk-Transcribe/go.mod
+++ b/Trunk-Transcribe/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/aws/aws-sdk-go v1.48.16
 	github.com/google/generative-ai-go v0.19.0
 	github.com/hashicorp/golang-lru/v2 v2.0.7
-	github.com/slack-go/slack v0.12.3
+	github.com/slack-go/slack v0.16.0
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/sync v0.7.0
 	google.golang.org/api v0.186.0


### PR DESCRIPTION
bumps the [`slack-go` client](github.com/slack-go/slack) to latest. And migrates away from a deprecated file upload api.